### PR TITLE
Support schemeless & scheme-relative URL's (fix #7)

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -9,6 +9,9 @@ var XMLHttpRequest = XMLHttpRequest || require('xhr2');
 
 /**
  * Upgrade the given URL to HTTPS if it's from a host known to support it.
+ *
+ * @param {string} urlString
+ * @return {string} processed URL string
  */
 var upgradeToHttps = function (urlString) {
   var secureHosts = [
@@ -19,9 +22,24 @@ var upgradeToHttps = function (urlString) {
     'cdn.jsdelivr.net',
     'ajax.aspnetcdn.com'
   ];
+
+  // Add a scheme to scheme-less URLs
+  var isRelative = !!urlString.match(/^\/\//);
+  if (isRelative) {
+    urlString = 'https:' + urlString;
+  }
+
+  // Prepend http for protocol-less URL's
   var urlObject = url.parse(urlString);
-  if (urlObject && (secureHosts.indexOf(urlObject.hostname) > -1)) {
-    urlObject.protocol = 'https';
+  if (!urlObject.protocol && !isRelative) {
+    urlString = 'http:' + '//' + urlString;
+    urlObject = url.parse(urlString);
+  }
+
+  // Upgrade http protocol to https, if host is on the secureHosts list
+  if (urlObject.protocol === 'http:'
+    && secureHosts.indexOf(urlObject.hostname) > -1) {
+    urlObject.protocol = 'https:';
   }
   return url.format(urlObject);
 }

--- a/test/test_helpers.js
+++ b/test/test_helpers.js
@@ -15,6 +15,12 @@ test(
     t.equals(unknownHttpsURL, 'https://example.com/script.js', 'HTTPS from unknown CDN');
     var unknownHttpURL = helpers.upgradeToHttps('http://example.com/script.js');
     t.equals(unknownHttpURL, 'http://example.com/script.js', 'HTTP from unknown CDN');
+    var schemelessURL = helpers.upgradeToHttps('example.com/script.js');
+    t.equals(schemelessURL, 'http://example.com/script.js', 'Schemeless URL');
+    var relativeSchemeURL = helpers.upgradeToHttps('//example.com/script.js');
+    t.equals(relativeSchemeURL, 'https://example.com/script.js', 'Relative scheme URL');
+    var schemelessKnownURL = helpers.upgradeToHttps('code.jquery.com/script.js');
+    t.equals(schemelessKnownURL, 'https://code.jquery.com/script.js', 'Schemeless known URL');
     t.end();
   }
 );


### PR DESCRIPTION
Scheme-relative URLs by definition work on HTTP and HTTPS both, so let's be opinionated and always upgrade people to HTTPS :)