### PR TITLE
Resources are now required to be loaded using CORS

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -210,11 +210,11 @@ var generateElement = function (resourceUrl, algorithms, cb) {
     switch (resource.type) {
     case 'js':
       element = '<script src="' + resource.url +
-        '" integrity="' + resource.integrity + '"></script>';
+        '" integrity="' + resource.integrity + '" crossorigin="anonymous"></script>';
       break;
     case 'css':
       element = '<link rel="stylesheet" href="' + resource.url +
-        '" integrity="' + resource.integrity + '">';
+        '" integrity="' + resource.integrity + '" crossorigin="anonymous">';
       break;
     case '.forbidden':
       element = 'Error: Forbidden content-type\n\n' +
@@ -225,7 +225,7 @@ var generateElement = function (resourceUrl, algorithms, cb) {
       element = '<!-- Warning: Unrecognized content-type. ' +
         'Are you sure this is the right resource? -->\n' +
         '<script src="' + resource.url +
-        '" integrity="' + resource.integrity + '"></script>';
+        '" integrity="' + resource.integrity + '" crossorigin="anonymous"></script>';
       break;
     }
 


### PR DESCRIPTION
That restriction doesn't apply to same-origin resources, but we
have no way to tell what users need and the most common use case
for srihash.org will be for cross-origin loads.