### PR TITLE
The bad headers we can check are the response ones

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -43,14 +43,13 @@ var upgradeToHttps = function (urlString) {
 
 
 /**
- * Check XHR request headers for issues that could affect SRI eligibility
+ * Check XHR response headers for issues that could affect SRI eligibility
  *
  * @param {Object.XMLHttpRequest} fetchResource request
  * @return {Array} list of potential issues
  */
 var eligibility = function (request) {
   var badHeaders = [
-    'authorization',
     'www-authenticate',
     'refresh'
   ];

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -76,12 +76,6 @@ describe('eligibility()', function () {
       var result = helpers.eligibility(badAuthenticate);
       assert.deepEqual(result, ['www-authenticate']);
     });
-
-    it('authorization', function () {
-      var badAuthorization = new FauxXHR({ headers: { 'authorization': 'baSe64DaTA' } });
-      var result = helpers.eligibility(badAuthorization);
-      assert.deepEqual(result, ['authorization']);
-    });
   });
 
   describe('Caching', function () {


### PR DESCRIPTION
`Authorization` is a request header.

I probably brought this confusion from my patch to Firefox since I had the [same problem there](https://bitbucket.org/fmarier/mozilla-central-mq-992096/commits/a56326ce1a5286b799cac53b571a6f66e5c31f47).