### PR TITLE
Rename subresource

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,15 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+
+Examples of unacceptable behavior by participants include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
+
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.1.0, available at [http://contributor-covenant.org/version/1/1/0/](http://contributor-covenant.org/version/1/1/0/)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 SRI Hash Generator
 ===================
 
-This is the code behind the <https://srihash.org> website. It generates [sub-resource integrity](http://www.w3.org/TR/SRI/) hashes.
+This is the code behind the <https://srihash.org> website. It generates [subresource integrity](http://www.w3.org/TR/SRI/) hashes.
 
 [![Build Status](https://travis-ci.org/mozilla/srihash.org.svg?branch=master)](https://travis-ci.org/mozilla/srihash.org)
 [![Coverage Status](https://coveralls.io/repos/mozilla/srihash.org/badge.svg?branch=master)](https://coveralls.io/r/mozilla/srihash.org?branch=master)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "srihash.org",
   "version": "0.1.0",
-  "description": "Sub-resource integrity attribute generator",
+  "description": "Subresource Integrity attribute generator",
   "main": "index.js",
   "scripts": {
     "start": "node ./index.js",

--- a/templates/index.html
+++ b/templates/index.html
@@ -36,11 +36,11 @@
 
     <!-- About -->
     <div id="about" class="container">
-      <h3>What is Sub-resource integrity?</h3>
+      <h3>What is Subresource Integrity?</h3>
       <p>SRI is a new <a href="http://www.w3.org/TR/SRI/">W3C specification</a> that allows web developers to ensure that resources hosted on third-party servers have not been tampered with. Use of SRI is recommended as a best-practice, whenever libraries are loaded from a third-party source.</p>
       <hr>
 
-      <h3>How is Sub-resource integrity different to HTTPS?</h3>
+      <h3>How is Subresource Integrity different to HTTPS?</h3>
       <p>TLS ensures that the connection between the browser and the server is secure. The resource itself may still be modified server-side by an attacker to include malicious content, yet still be served with a valid TLS certificate. SRI, on the other hand, guarantees that a resource hasn't changed since it was hashed by a web author.</p>
       <hr>
 
@@ -55,7 +55,7 @@
       <hr>
 
       <h3>Test your browser</h3>
-      <p>To fully test your browser for sub-resource integrity support, please open <a href="http://w3c-test.org/subresource-integrity/subresource-integrity.html">this page</a>.</p>
+      <p>To fully test your browser for subresource integrity support, please open <a href="http://w3c-test.org/subresource-integrity/subresource-integrity.html">this page</a>.</p>
 
       <div class="sri-test" id="sri-badge">
         <link rel="stylesheet" href="/badge/will-pass.css">


### PR DESCRIPTION
Just realised @neftaly this has come with the code of conduct from a previous commit. (sorry about that it really wasn't intentional)

Gives me a chance to poke @fmarier again to see if he approves.

The change itself is just to get consistency for SRI with the spec.