### PR TITLE
avoid useless use of cat, use openssl base64

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -48,8 +48,7 @@
       <h3>How can I generate Integrity hashes?</h3>
       <p>Use the generator above or the following shell command:<br>
         <code>
-          cat <strong>FILENAME.js</strong> |<br>
-          openssl dgst -sha384 -binary |<br>
+          openssl dgst -sha384 -binary <strong>FILENAME.js</strong> |<br>
           openssl enc -base64 -A
         </code>
       </p>


### PR DESCRIPTION
Simplified shell version to avoid useless use of cat award (cf. http://porkmail.org/era/unix/award.html). Also, openssl base64 is shorter/easier to remember than openssl enc -base64 -A ...