### PR TITLE
Replace type="text" by type="url" in the main input

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -25,7 +25,7 @@
           <h1>SRI Hash Generator</h1>
           <div>Enter the URL of the resource you wish to use:</div>
           <form method="POST" action="/hash" target="sriSnippet">
-            <input name="url" type="text" value="" placeholder="Resource URL" required>
+            <input name="url" type="url" value="" placeholder="Resource URL" required>
             <input name="algorithms" value="sha384" type="hidden">
             <input type="submit" value="Hash!">
           </form>


### PR DESCRIPTION
I suggest to replace type="text" by type="url" to mobile users can easily write their URL address.
