### PR TITLE
Tweak security headers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,19 @@ var CSP_HEADER = "default-src 'none'; img-src 'self'; style-src 'self'; font-src
 var server = new Hapi.Server();
 server.connection({
   port: process.env.PORT || 4000,
-  routes: { security: { xframe: 'sameorigin' } }
+  routes: {
+    security: {
+      hsts: {
+        maxAge: 31536000,
+        includeSubDomains: true,
+        preload: true
+      },
+      noSniff: true,
+      noOpen: true,
+      xframe: 'sameorigin',
+      xss: true
+    }
+  }
 });
 
 server.register(require('vision'), function () {


### PR DESCRIPTION
Specify HSTS preload.
Also, explicitly set the default ones.

Next step would be to make sure we comply with the HSTS preload list requirements and submit the URL https://hstspreload.appspot.com/

