### PR TITLE
Specify cache-control header.

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,13 @@ server.register(require('inert'), function () {
     handler: {
       directory: {
         path: 'public',
+        etagMethod: false,
         lookupCompressed: true
+      }
+    },
+    config: {
+      cache: {
+        expiresIn: 60 * 60 * 1000   // 1 hour
       }
     }
   });


### PR DESCRIPTION
Set to 1 hour since there's no cache busting.

Fixes #118