### PR TITLE
Fixing #149: Send `Origin` header for outgoing requests (AWS EC2 needs this)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,4 @@ script:
   - npm test
 
 after_script: NODE_ENV=test istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage
+sudo: required # for networking?

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -128,7 +128,10 @@ var fetchResource = function (resourceUrl, cb) {
     return cb(false);
   }
 
-  moduleForProtocol(resourceUrl).get(resourceUrl, function (response) {
+  moduleForProtocol(resourceUrl).get({
+    hostname: resourceUrl,
+    headers: { 'Origin': 'https://srihash.org/' },
+  }, function (response) {
     var output;
     if (response.headers['content-encoding'] === 'gzip') {
       var gzip = zlib.createGunzip();


### PR DESCRIPTION
@fmarier Can you take a look? I'm quite uncertain about how to test this.
