### PR TITLE
Add fonts.googleapis.com to the list of HTTPS hosts

### DIFF
--- a/lib/secureHosts.json
+++ b/lib/secureHosts.json
@@ -1,6 +1,7 @@
 [
   "code.jquery.com",
   "ajax.googleapis.com",
+  "fonts.googleapis.com",
   "maxcdn.bootstrapcdn.com",
   "cdnjs.cloudflare.com",
   "cdn.jsdelivr.net",


### PR DESCRIPTION
This is so that a URL like http://fonts.googleapis.com/css?family=Open+Sans:400,600,300,700,800 gets automatically upgraded to https://fonts.googleapis.com/css?family=Open+Sans:400,600,300,700,800.