### PR TITLE
Hapi: specify HSTS header.

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,16 @@ var CSP_HEADER = "default-src 'none'; img-src 'self'; style-src 'self'; font-src
 
 server.connection({
   port: process.env.PORT || 4000,
-  routes: { security: { xframe: 'sameorigin' } }
+  routes: {
+    security: {
+      hsts: {
+        includeSubDomains: true,
+        maxAge: 31536000,
+        preload: true
+      },
+      xframe: 'sameorigin'
+    }
+  }
 });
 
 server.register(vision, function () {


### PR DESCRIPTION
Before, the default was being used, which isn't what the header needs to be for the domain to be eligible for submission to the HSTS preload list.