### PR TITLE
Add hapi-require-https.

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const Hapi = require('hapi');
 const vision = require('vision');
 const inert = require('inert');
 const sitemap = require('hapi-sitemap');
+const requireHttps = require('hapi-require-https');
 
 const handlebarsHelperSRI = require('handlebars-helper-sri');
 let handlebars = require('handlebars');
@@ -144,6 +145,15 @@ server.register(inert, () => {
     }
   });
 });
+
+if (process.env.NODE_ENV === 'production') {
+  server.register({
+    register: requireHttps,
+    options: {
+      proxy: false
+    }
+  });
+}
 
 server.register({
   register: sitemap,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2694,6 +2694,11 @@
         "topo": "2.x.x"
       }
     },
+    "hapi-require-https": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hapi-require-https/-/hapi-require-https-2.1.0.tgz",
+      "integrity": "sha1-RA42TNQul54C3wXpGt/Z2gO0qnI="
+    },
     "hapi-sitemap": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/hapi-sitemap/-/hapi-sitemap-1.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "handlebars": "^4.1.1",
     "handlebars-helper-sri": "0.0.0",
     "hapi": "^16.6.3",
+    "hapi-require-https": "^2.1.0",
     "hapi-sitemap": "^1.0.3",
     "inert": "^4.2.1",
     "sri-toolbox": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
     "eslint": "eslint .",
     "stylelint": "stylelint \"**/*.css\"",
     "lint": "npm run stylelint && npm run eslint",
-    "mocha": "mocha test",
-    "start": "cross-env NODE_ENV=production node ./index.js",
-    "start-dev": "cross-env NODE_ENV=development node ./index.js",
+    "mocha": "mocha",
+    "server": "node ./index.js",
+    "start": "cross-env NODE_ENV=production npm run server",
     "test": "npm run copyright && npm run lint && npm run mocha",
     "travis": "nyc npm test",
-    "watch": "nodemon index.js --ext css,js,html --exec \"npm run start-dev\""
+    "watch": "nodemon index.js --ext css,js,html --exec \"npm run server\""
   },
   "dependencies": {
     "cross-env": "^5.2.0",


### PR DESCRIPTION
If the production script is running `npm start` this will work out of the box. Otherwise we might need to set the env var `NODE_ENV` to `production`.

Requires the previous PRs merged.

Fixes #122.

/CC @fmarier 