### PR TITLE
Remove the list of browsers that support SRI

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,15 +55,9 @@ server.register(inert, () => {
     method: 'GET',
     path: '/',
     handler(request, reply) {
-      const browsers = helpers.shuffleArray([
-        { name: 'Firefox', url: 'https://www.mozilla.org/firefox/' },
-        { name: 'Safari', url: 'https://www.apple.com/safari/' },
-        { name: 'Chrome', url: 'https://www.google.com/chrome/browser/desktop/' }
-      ]);
       reply
         .view('index', {
-          title: 'SRI Hash Generator',
-          browsers
+          title: 'SRI Hash Generator'
         })
         .header('Content-Security-Policy', CSP_HEADER)
         .header('Referrer-Policy', REFERRER_HEADER);

--- a/templates/index.html
+++ b/templates/index.html
@@ -60,8 +60,6 @@
       <hr>
 
       <h2>Test your browser</h2>
-      <p><a href="{{browsers.0.url}}">{{browsers.0.name}}</a>, <a href="{{browsers.1.url}}">{{browsers.1.name}}</a> and <a href="{{browsers.2.url}}">{{browsers.2.name}}</a> all support SRI.</p>
-
       <p>Check out <a href="https://caniuse.com/#feat=subresource-integrity">SRI on caniuse.com</a> to see specific browser version support information.</p>
 
       <p>To fully test your browser for subresource integrity support, please open <a href="http://w3c-test.org/subresource-integrity/subresource-integrity.sub.html">this page</a>.</p>


### PR DESCRIPTION
Now that Safari (issue 186) and Edge support SRI, there's no point
in explicitly listing all of the browsers that support it.