### PR TITLE
[WIP] Update Hapi to v18 and its plugins.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,9 @@
     "es6": true,
     "node": true
   },
+  "parserOptions": {
+    "ecmaVersion": 2017
+  },
   "extends": "eslint:recommended",
   "rules": {
     "accessor-pairs": "error",

--- a/index.js
+++ b/index.js
@@ -88,17 +88,14 @@ const REFERRER_HEADER = 'no-referrer, strict-origin-when-cross-origin';
     server.route({
       method: 'POST',
       path: '/generate',
-      handler(request, h) {
+      handler: async(request, h) => {
         const options = {
           url: request.payload.url,
           algorithms: request.payload.algorithms
         };
+        const result = await generate(options);
 
-        generate(options, (result) => {
-          return h.response(
-            JSON.stringify(result)
-          ).type('application/json');
-        });
+        return h.response(JSON.stringify(result)).type('application/json');
       }
     });
 

--- a/index.js
+++ b/index.js
@@ -106,16 +106,15 @@ const REFERRER_HEADER = 'no-referrer, strict-origin-when-cross-origin';
     server.route({
       method: 'POST',
       path: '/hash',
-      handler(request, h) {
-        generateElement(
+      handler: async(request, h) => {
+        const result = await generateElement(
           request.payload.url,
-          request.payload.algorithms,
-          (result) => {
-            return h.view('hash', { hash: result })
-              .header('Content-Security-Policy', CSP_HEADER)
-              .header('Referrer-Policy', REFERRER_HEADER);
-          }
+          request.payload.algorithms
         );
+
+        return h.view('hash', { hash: result })
+          .header('Content-Security-Policy', CSP_HEADER)
+          .header('Referrer-Policy', REFERRER_HEADER);
       }
     });
 

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -15,42 +15,44 @@ const fetchResource = require('./fetchResource');
  * @param {Object} options - Options Object
  * @param {string|Array} options.algorithms - Desired hash algorithm(s)
  * @param {string} options.url - Resource URL
- * @param {Function} cb - callback
+ * @return {Promise}
  */
-const generate = (options, cb) => {
-  if (typeof options.algorithms === 'string') {
-    options.algorithms = [options.algorithms];
-  }
-
-  fetchResource(options.url, (resource) => {
-    if (!resource) {
-      return cb({
-        success: false,
-        status: 0
-      });
+const generate = (options) => {
+  return new Promise((resolve) => {
+    if (typeof options.algorithms === 'string') {
+      options.algorithms = [options.algorithms];
     }
 
-    if (resource.status !== 200) {
-      return cb(resource);
-    }
+    fetchResource(options.url, (resource) => {
+      if (!resource) {
+        return resolve({
+          success: false,
+          status: 0
+        });
+      }
 
-    const sri = sriToolbox.generate({
-      algorithms: options.algorithms,
-      full: true
-    }, resource.data);
+      if (resource.status !== 200) {
+        return resolve(resource);
+      }
 
-    const contentType = getResourceTypeFromContentTypeHeader(resource.ct);
+      const sri = sriToolbox.generate({
+        algorithms: options.algorithms,
+        full: true
+      }, resource.data);
 
-    return cb({
-      success: true,
-      status: resource.status,
-      url: resource.url,
-      type: guessResourceType({
+      const contentType = getResourceTypeFromContentTypeHeader(resource.ct);
+
+      return resolve({
+        success: true,
+        status: resource.status,
         url: resource.url,
-        ct: contentType
-      }),
-      integrity: sri.integrity,
-      eligibility: resource.eligibility
+        type: guessResourceType({
+          url: resource.url,
+          ct: contentType
+        }),
+        integrity: sri.integrity,
+        eligibility: resource.eligibility
+      });
     });
   });
 };

--- a/lib/generateElement.js
+++ b/lib/generateElement.js
@@ -12,49 +12,51 @@ const generate = require('./generate');
  * @deprecated pending move to isomorphic app
  * @param {string} resourceUrl - Resource URL
  * @param {Array} algorithms - The desired hash algorithms
- * @param {Function} cb - callback
+ * @return {Promise}
  */
-const generateElement = (resourceUrl, algorithms, cb) => {
-  const options = {
-    url: resourceUrl,
-    algorithms
-  };
+const generateElement = (resourceUrl, algorithms) => {
+  return new Promise((resolve) => {
+    const options = {
+      url: resourceUrl,
+      algorithms
+    };
 
-  generate(options, (resource) => {
-    let element;
+    generate(options).then((resource) => {
+      let element;
 
-    if (!resource.success) {
-      if (resource.status > 0) {
-        return cb(`Error: fetching the resource returned a ${parseInt(resource.status, 10)} error code.`);
+      if (!resource.success) {
+        if (resource.status > 0) {
+          return resolve(`Error: fetching the resource returned a ${parseInt(resource.status, 10)} error code.`);
+        }
+
+        return resolve('Error: fetching the resource returned an unexpected error.');
       }
 
-      return cb('Error: fetching the resource returned an unexpected error.');
-    }
+      if (resource.eligibility.length !== 0) {
+        return resolve('Error: this resource is not eligible for integrity checks. See https://enable-cors.org/server.html');
+      }
 
-    if (resource.eligibility.length !== 0) {
-      return cb('Error: this resource is not eligible for integrity checks. See https://enable-cors.org/server.html');
-    }
+      switch (resource.type) {
+        case 'js':
+          element = `<script src="${resource.url}" integrity="${resource.integrity}" crossorigin="anonymous"></script>`;
+          break;
+        case 'css':
+          element = `<link rel="stylesheet" href="${resource.url}" integrity="${resource.integrity}" crossorigin="anonymous">`;
+          break;
+        case '.forbidden':
+          element = `Error: Forbidden content-type
 
-    switch (resource.type) {
-      case 'js':
-        element = `<script src="${resource.url}" integrity="${resource.integrity}" crossorigin="anonymous"></script>`;
-        break;
-      case 'css':
-        element = `<link rel="stylesheet" href="${resource.url}" integrity="${resource.integrity}" crossorigin="anonymous">`;
-        break;
-      case '.forbidden':
-        element = `Error: Forbidden content-type
-
-           https://html.spec.whatwg.org/multipage/scripting.html#scriptingLanguages
-           https://developer.mozilla.org/en/docs/Incorrect_MIME_Type_for_CSS_Files`;
-        break;
-      default:
-        element = `<!-- Warning: Unrecognized content-type. Are you sure this is the right resource? -->
+             https://html.spec.whatwg.org/multipage/scripting.html#scriptingLanguages
+             https://developer.mozilla.org/en/docs/Incorrect_MIME_Type_for_CSS_Files`;
+          break;
+        default:
+          element = `<!-- Warning: Unrecognized content-type. Are you sure this is the right resource? -->
 <script src="${resource.url}" integrity="${resource.integrity}" crossorigin="anonymous"></script>`;
-        break;
-    }
+          break;
+      }
 
-    return cb(element);
+      return resolve(element);
+    });
   });
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -160,6 +160,303 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@hapi/accept": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-3.2.2.tgz",
+      "integrity": "sha512-UtXlTT59srtMr7ZRBzK2CvyWqFwlf78hPt9jEXqkwfbwiwRH1PRv/qkS8lgr5ZyoG6kfpU3xTgt2X91Yfe/6Yg==",
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "6.x.x"
+      }
+    },
+    "@hapi/address": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
+      "integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw=="
+    },
+    "@hapi/ammo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-3.1.0.tgz",
+      "integrity": "sha512-iFQBEfm3WwWy8JdPQ8l6qXVLPtzmjITVfaxwl6dfoP8kKv6i2Uk43Ax+ShkNfOVyfEnNggqL2IyZTY3DaaRGNg==",
+      "requires": {
+        "@hapi/hoek": "6.x.x"
+      }
+    },
+    "@hapi/b64": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-4.2.0.tgz",
+      "integrity": "sha512-hmfPC1aF7cP21489A/IWPC3s1GE+1eAteVwFcOWLwj0Pky8eHgvrXPSSko2IeCpxqOdZhYw71IFN8xKPdv3CtQ==",
+      "requires": {
+        "@hapi/hoek": "6.x.x"
+      }
+    },
+    "@hapi/boom": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.2.tgz",
+      "integrity": "sha512-T2CYcTI0AqSvC6YC7keu/fh9LVSMzfoMLharBnPbOwmc+Cexj9joIc5yNDKunaxYq9LPuOwMS0f2B3S1tFQUNw==",
+      "requires": {
+        "@hapi/hoek": "6.x.x"
+      }
+    },
+    "@hapi/bounce": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-1.3.0.tgz",
+      "integrity": "sha512-gF5W/9AL10h/06HEf1bi0FP6KxZZ8LC/yHtDuoACw+1HrULvigHfnBIaSPFJXeHI3V3g0EkJpt1UOW0NKB+m+w==",
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "6.x.x"
+      }
+    },
+    "@hapi/bourne": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
+      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
+    },
+    "@hapi/call": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-5.1.0.tgz",
+      "integrity": "sha512-CiVEXjD/jiIHBqufBW3pdedshEMjRmHtff7m1puot8j4MUmuKRbLlh0DB8fv6QqH/7/55pH1qgFj300r0WpyMw==",
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "6.x.x"
+      }
+    },
+    "@hapi/catbox": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-10.2.1.tgz",
+      "integrity": "sha512-u13BXlnmmrNUZssjTriRVTLuk6I/yUy5C1/Pia1+E2cpfd7o2/jmEvYdFgeS0Ft9QTz7WWhpXKlrguARUuohhQ==",
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "6.x.x",
+        "@hapi/joi": "15.x.x",
+        "@hapi/podium": "3.x.x"
+      }
+    },
+    "@hapi/catbox-memory": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-4.1.0.tgz",
+      "integrity": "sha512-libCGyufOZaJu6uE9nVXw/u8tqOt4ifNIrOSAsDjzS+af3vPJyid8faOICqKCAh3E338UAsUe5AeYdezdsmtpg==",
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "6.x.x"
+      }
+    },
+    "@hapi/content": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-4.1.0.tgz",
+      "integrity": "sha512-hv2Czsl49hnWDEfRZOFow/BmYbKyfEknmk3k83gOp6moFn5ceHB4xVcna8OwsGfy8dxO81lhpPy+JgQEaU4SWw==",
+      "requires": {
+        "@hapi/boom": "7.x.x"
+      }
+    },
+    "@hapi/cryptiles": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-4.2.0.tgz",
+      "integrity": "sha512-P+ioMP1JGhwDOKPRuQls6sT/ln6Fk+Ks6d90mlBi6HcOu5itvdUiFv5Ynq2DvLadPDWaA43lwNxkfZrjE9s2MA==",
+      "requires": {
+        "@hapi/boom": "7.x.x"
+      }
+    },
+    "@hapi/hapi": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-18.3.1.tgz",
+      "integrity": "sha512-gBiU9isWWezrg0ucX95Ph6AY6fUKZub3FxKapaleoFBJDOUcxTYiQR6Lha2zvHalIFoTl3K04O3Yr/5pD17QkQ==",
+      "requires": {
+        "@hapi/accept": "3.x.x",
+        "@hapi/ammo": "3.x.x",
+        "@hapi/boom": "7.x.x",
+        "@hapi/bounce": "1.x.x",
+        "@hapi/call": "5.x.x",
+        "@hapi/catbox": "10.x.x",
+        "@hapi/catbox-memory": "4.x.x",
+        "@hapi/heavy": "6.x.x",
+        "@hapi/hoek": "6.x.x",
+        "@hapi/joi": "15.x.x",
+        "@hapi/mimos": "4.x.x",
+        "@hapi/podium": "3.x.x",
+        "@hapi/shot": "4.x.x",
+        "@hapi/somever": "2.x.x",
+        "@hapi/statehood": "6.x.x",
+        "@hapi/subtext": "6.x.x",
+        "@hapi/teamwork": "3.x.x",
+        "@hapi/topo": "3.x.x"
+      }
+    },
+    "@hapi/heavy": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-6.2.0.tgz",
+      "integrity": "sha512-tzGU9cElY0IxRBudGB7tLFkdpBD8XQPfd6G7DSOnvHRK+q96UHGHn4t59Yd7kDpVucNkErWWYarsGx2KmKPkXA==",
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "6.x.x",
+        "@hapi/joi": "15.x.x"
+      }
+    },
+    "@hapi/hoek": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.1.tgz",
+      "integrity": "sha512-+ryw4GU9pjr1uT6lBuErHJg3NYqzwJTvZ75nKuJijEzpd00Uqi6oiawTGDDf5Hl0zWmI7qHfOtaqB0kpQZJQzA=="
+    },
+    "@hapi/inert": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/inert/-/inert-5.2.0.tgz",
+      "integrity": "sha512-ytsYA46CQOj8AJ3j4keRMj0S1k2XPMuhrlxo/uBY3EJvfRlRs8LtIBIYDW+kmcAqnVaZggcYq4ngKt9H/eEIAA==",
+      "requires": {
+        "@hapi/ammo": "3.x.x",
+        "@hapi/boom": "7.x.x",
+        "@hapi/bounce": "1.x.x",
+        "@hapi/hoek": "6.x.x",
+        "@hapi/joi": "15.x.x",
+        "lru-cache": "4.1.x"
+      }
+    },
+    "@hapi/iron": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-5.1.0.tgz",
+      "integrity": "sha512-+MK3tBPkEKd50SrDTRXa2DVvE0UTPFKxGbodlbQpNP9SVlxi+ZwA640VJtMNj84FZh81UUxda8AOLPRKFffnEA==",
+      "requires": {
+        "@hapi/b64": "4.x.x",
+        "@hapi/boom": "7.x.x",
+        "@hapi/cryptiles": "4.x.x",
+        "@hapi/hoek": "6.x.x"
+      }
+    },
+    "@hapi/joi": {
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.0.3.tgz",
+      "integrity": "sha512-z6CesJ2YBwgVCi+ci8SI8zixoj8bGFn/vZb9MBPbSyoxsS2PnWYjHcyTM17VLK6tx64YVK38SDIh10hJypB+ig==",
+      "requires": {
+        "@hapi/address": "2.x.x",
+        "@hapi/hoek": "6.x.x",
+        "@hapi/topo": "3.x.x"
+      }
+    },
+    "@hapi/mimos": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-4.1.0.tgz",
+      "integrity": "sha512-CkxOB15TFZDMl5tQ5qezKZvvBnkRYVc8YksNfA5TnqQMMsU7vGPyvuuNFqj+15bfEwHyM6qasxyQNdkX9B/cQw==",
+      "requires": {
+        "@hapi/hoek": "6.x.x",
+        "mime-db": "1.x.x"
+      }
+    },
+    "@hapi/nigel": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-3.1.0.tgz",
+      "integrity": "sha512-IJyau32pz5Bf7pzUU/8AIn/SvPvhLMQcOel6kM7ECpKyPc895AwttSusRKfgTwfxZOEG6W8DnNv25gLtqrVFSg==",
+      "requires": {
+        "@hapi/hoek": "6.x.x",
+        "@hapi/vise": "3.x.x"
+      }
+    },
+    "@hapi/pez": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-4.1.0.tgz",
+      "integrity": "sha512-c+AxL8/cCj+7FB+tzJ5FhWKYP8zF7/7mA3Ft3a5y7h6YT26qzhj5d2JY27jur30KaZbrZAd4ofXXkqvE/IpJlA==",
+      "requires": {
+        "@hapi/b64": "4.x.x",
+        "@hapi/boom": "7.x.x",
+        "@hapi/content": "4.x.x",
+        "@hapi/hoek": "6.x.x",
+        "@hapi/nigel": "3.x.x"
+      }
+    },
+    "@hapi/podium": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-3.4.0.tgz",
+      "integrity": "sha512-IwyewAPGlCoq+g5536PKSDqSTfgpwbj+q4cBJpEUNqzwc5C5SM2stuFsULU7x1jKeWevfgWDoYWC75ML4IOYug==",
+      "requires": {
+        "@hapi/hoek": "6.x.x",
+        "@hapi/joi": "15.x.x"
+      }
+    },
+    "@hapi/shot": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-4.1.0.tgz",
+      "integrity": "sha512-rpUU5cF08fqAZLLnue6Sy0osj1QMPbrYskehxtLFPdk7CwlPcu9N/wRtgu7vDHTQCKTkag6M8sjc8V8p8lSxpg==",
+      "requires": {
+        "@hapi/hoek": "6.x.x",
+        "@hapi/joi": "15.x.x"
+      }
+    },
+    "@hapi/somever": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-2.1.0.tgz",
+      "integrity": "sha512-kMPewbpgLd0MSlNg0bjvq57Levozbg7c3O0idpWRxRgXfXBALNATLf8GRVbnMehYXAh7YRD2mR/91kginDtJ2Q==",
+      "requires": {
+        "@hapi/bounce": "1.x.x",
+        "@hapi/hoek": "6.x.x"
+      }
+    },
+    "@hapi/statehood": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-6.1.0.tgz",
+      "integrity": "sha512-qc8Qq3kg0b3XK7siXf6DK0wp+rcOrXv336kIP6YrtD9TbQ45TsBobwKkUXB+4R3GCCQ8a6tOj8FR/9bdtjKJCA==",
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/bounce": "1.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/cryptiles": "4.x.x",
+        "@hapi/hoek": "6.x.x",
+        "@hapi/iron": "5.x.x",
+        "@hapi/joi": "15.x.x"
+      }
+    },
+    "@hapi/subtext": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-6.1.0.tgz",
+      "integrity": "sha512-dNL4IspNciKUK9RJuArwyS1MO07ZU64z4JrCzY1+vRKczYqin8M5i34cpOrQNP3pD/A/6IbRcFg0Jl0G6pwjnA==",
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/content": "4.x.x",
+        "@hapi/hoek": "6.x.x",
+        "@hapi/pez": "4.x.x",
+        "@hapi/wreck": "15.x.x"
+      }
+    },
+    "@hapi/teamwork": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-3.3.1.tgz",
+      "integrity": "sha512-61tiqWCYvMKP7fCTXy0M4VE6uNIwA0qvgFoiDubgfj7uqJ0fdHJFQNnVPGrxhLWlwz0uBPWrQlBH7r8y9vFITQ=="
+    },
+    "@hapi/topo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.0.tgz",
+      "integrity": "sha512-gZDI/eXOIk8kP2PkUKjWu9RW8GGVd2Hkgjxyr/S7Z+JF+0mr7bAlbw+DkTRxnD580o8Kqxlnba9wvqp5aOHBww==",
+      "requires": {
+        "@hapi/hoek": "6.x.x"
+      }
+    },
+    "@hapi/vise": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-3.1.0.tgz",
+      "integrity": "sha512-DUDzV0D4iVO5atghsjGZtzaF0HVtRLcxcnH6rAONyH0stnoLiFloGEuP5nkbIPU0B9cgWTzTUsQPuNHBzxy9Yw==",
+      "requires": {
+        "@hapi/hoek": "6.x.x"
+      }
+    },
+    "@hapi/vision": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@hapi/vision/-/vision-5.5.2.tgz",
+      "integrity": "sha512-jB+KsxiXS89cwQcoDvxJsq9iuHdVBVdIlqfvCDI/+CFdnatVkuAi53Zemxx9HtZaDeW+ZFZ6wruLIJOGQI/nlg==",
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/bounce": "1.x.x",
+        "@hapi/hoek": "6.x.x",
+        "@hapi/joi": "15.x.x"
+      }
+    },
+    "@hapi/wreck": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-15.0.1.tgz",
+      "integrity": "sha512-ByXQna/W1FZk7dg8NEhL79u4QkhzszRz76VpgyGstSH8bLM01a0C8RsxmUBgi6Tjkag5jA9kaEIhF9dLpMrtBw==",
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/hoek": "6.x.x"
+      }
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -238,15 +535,6 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
-    "accept": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/accept/-/accept-2.1.4.tgz",
-      "integrity": "sha1-iHr1TO7lx/RDBGGXHsQAxh0JrLs=",
-      "requires": {
-        "boom": "5.x.x",
-        "hoek": "4.x.x"
-      }
-    },
     "acorn": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
@@ -269,31 +557,6 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
-      }
-    },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "optional": true,
-      "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
-      }
-    },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
-    },
-    "ammo": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/ammo/-/ammo-2.0.4.tgz",
-      "integrity": "sha1-v4CqshFpjqePY+9efxE91dnokX8=",
-      "requires": {
-        "boom": "5.x.x",
-        "hoek": "4.x.x"
       }
     },
     "ansi-align": {
@@ -499,11 +762,6 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
-    "b64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/b64/-/b64-3.0.3.tgz",
-      "integrity": "sha512-Pbeh0i6OLubPJdIdCepn8ZQHwN2MWznZHbHABSTEfQ706ie+yuxNSaPdqX1xRatT6WanaS1EazMiSg0NUW2XxQ=="
-    },
     "bail": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.4.tgz",
@@ -568,12 +826,6 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
         }
       }
     },
@@ -591,19 +843,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true
-    },
-    "boom": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-      "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-      "requires": {
-        "hoek": "4.x.x"
-      }
-    },
-    "bourne": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/bourne/-/bourne-1.1.2.tgz",
-      "integrity": "sha512-b2dgVkTZhkQirNMohgC00rWfpVqEi9y5tKM1k3JvoNx05ODtfQoPPd4js9CYFQoY0IM8LAmnJulEuWv74zjUOg=="
     },
     "boxen": {
       "version": "1.3.0",
@@ -731,15 +970,6 @@
         }
       }
     },
-    "call": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/call/-/call-4.0.2.tgz",
-      "integrity": "sha1-33b19R7o3Ui4VqyEAPfmnm1zmcQ=",
-      "requires": {
-        "boom": "5.x.x",
-        "hoek": "4.x.x"
-      }
-    },
     "call-me-maybe": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
@@ -779,10 +1009,10 @@
       "dev": true
     },
     "camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-      "optional": true
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
     },
     "camelcase-keys": {
       "version": "4.2.0",
@@ -821,52 +1051,11 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
-    "catbox": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/catbox/-/catbox-7.1.5.tgz",
-      "integrity": "sha512-4fui5lELzqZ+9cnaAP/BcqXTH6LvWLBRtFhJ0I4FfgfXiSaZcf6k9m9dqOyChiTxNYtvLk7ZMYSf7ahMq3bf5A==",
-      "requires": {
-        "boom": "5.x.x",
-        "hoek": "4.x.x",
-        "joi": "10.x.x"
-      },
-      "dependencies": {
-        "joi": {
-          "version": "10.6.0",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
-          "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
-          "requires": {
-            "hoek": "4.x.x",
-            "isemail": "2.x.x",
-            "items": "2.x.x",
-            "topo": "2.x.x"
-          }
-        }
-      }
-    },
-    "catbox-memory": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-2.0.4.tgz",
-      "integrity": "sha1-Qz4lWQLK9UIz0ShkKcj03xToItU=",
-      "requires": {
-        "hoek": "4.x.x"
-      }
-    },
     "ccount": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.4.tgz",
       "integrity": "sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w==",
       "dev": true
-    },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "optional": true,
-      "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
-      }
     },
     "chalk": {
       "version": "2.4.2",
@@ -980,22 +1169,14 @@
       "dev": true
     },
     "cliui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "optional": true,
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+      "dev": true,
       "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
-        "wordwrap": "0.0.2"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "optional": true
-        }
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
+        "wrap-ansi": "^2.0.0"
       }
     },
     "clone-regexp": {
@@ -1090,14 +1271,6 @@
         "unique-string": "^1.0.0",
         "write-file-atomic": "^2.0.0",
         "xdg-basedir": "^3.0.0"
-      }
-    },
-    "content": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/content/-/content-3.0.7.tgz",
-      "integrity": "sha512-LXtnSnvE+Z1Cjpa3P9gh9kb396qV4MqpfwKy777BOSF8n6nw2vAi03tHNl0/XRqZUyzVzY/+nMXOZVnEapWzdg==",
-      "requires": {
-        "boom": "5.x.x"
       }
     },
     "convert-source-map": {
@@ -1234,14 +1407,6 @@
         "which": "^1.2.9"
       }
     },
-    "cryptiles": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.4.tgz",
-      "integrity": "sha512-8I1sgZHfVwcSOY6mSGpVU3lw/GSIZvusg8dD2+OGehCJpOhQRLNcH0qb9upQnOH4XhgxxFJSg6E2kx95deb1Tw==",
-      "requires": {
-        "boom": "5.x.x"
-      }
-    },
     "crypto-random-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
@@ -1278,7 +1443,8 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "decamelize-keys": {
       "version": "1.1.0",
@@ -1372,12 +1538,6 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
         }
       }
     },
@@ -1831,12 +1991,6 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
         }
       }
     },
@@ -1964,14 +2118,6 @@
       "dev": true,
       "requires": {
         "is-buffer": "~2.0.3"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
-          "dev": true
-        }
       }
     },
     "flat-cache": {
@@ -2715,14 +2861,6 @@
         "ini": "^1.3.5",
         "kind-of": "^6.0.2",
         "which": "^1.3.1"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        }
       }
     },
     "globals": {
@@ -2836,79 +2974,6 @@
         "subresource": "0.0.0"
       }
     },
-    "hapi": {
-      "version": "16.7.0",
-      "resolved": "https://registry.npmjs.org/hapi/-/hapi-16.7.0.tgz",
-      "integrity": "sha512-UeMX1LMWmHEIgMlwZGK/3lhI7X0VRvOioVply0Y9qF+/O5woGdQzNB8ZmDnLOBjnB6bdWWHyo5DEamuCsE1vmg==",
-      "requires": {
-        "accept": "2.x.x",
-        "ammo": "2.x.x",
-        "boom": "5.x.x",
-        "call": "4.x.x",
-        "catbox": "7.x.x",
-        "catbox-memory": "2.x.x",
-        "cryptiles": "3.x.x",
-        "heavy": "4.x.x",
-        "hoek": "4.x.x",
-        "iron": "4.x.x",
-        "items": "2.x.x",
-        "joi": "11.x.x",
-        "mimos": "3.x.x",
-        "podium": "1.x.x",
-        "shot": "3.x.x",
-        "somever": "1.x.x",
-        "statehood": "5.x.x",
-        "subtext": "5.x.x",
-        "topo": "2.x.x"
-      }
-    },
-    "hapi-sitemap": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/hapi-sitemap/-/hapi-sitemap-1.0.3.tgz",
-      "integrity": "sha1-s4rxqyZwVQ6MxoJx+tTUe6kdynA=",
-      "requires": {
-        "handlebars": "^3.0.3"
-      },
-      "dependencies": {
-        "handlebars": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.6.tgz",
-          "integrity": "sha512-LxzdOvkYFsdL6ZT92igXthJIZLYKBSowtrM3oxfMdOwjv0dRWk6EK4PygNgXc0xwjH38BWMCSnktrOpKbec+Qw==",
-          "requires": {
-            "optimist": "^0.6.1",
-            "source-map": "^0.1.40",
-            "uglify-js": "^2.6"
-          }
-        },
-        "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-          "optional": true,
-          "requires": {
-            "source-map": "~0.5.1",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.10.0"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-              "optional": true
-            }
-          }
-        }
-      }
-    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -2967,6 +3032,12 @@
         "kind-of": "^4.0.0"
       },
       "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
+        },
         "kind-of": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
@@ -2992,34 +3063,6 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
-    },
-    "heavy": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/heavy/-/heavy-4.0.4.tgz",
-      "integrity": "sha1-NskTNsAMz+hSyqTRUwhjNc0vAOk=",
-      "requires": {
-        "boom": "5.x.x",
-        "hoek": "4.x.x",
-        "joi": "10.x.x"
-      },
-      "dependencies": {
-        "joi": {
-          "version": "10.6.0",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
-          "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
-          "requires": {
-            "hoek": "4.x.x",
-            "isemail": "2.x.x",
-            "items": "2.x.x",
-            "topo": "2.x.x"
-          }
-        }
-      }
-    },
-    "hoek": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
     },
     "hosted-git-info": {
       "version": "2.7.1",
@@ -3126,32 +3169,6 @@
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
       "dev": true
     },
-    "inert": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/inert/-/inert-4.2.1.tgz",
-      "integrity": "sha512-qmbbZYPSzU/eOUOStPQvSjrU9IR1Q3uDtsEsVwnBQeZG43xu7Nrj6yuUrX3ice/03rv5dj/KiKB+NGCbiqH+aQ==",
-      "requires": {
-        "ammo": "2.x.x",
-        "boom": "5.x.x",
-        "hoek": "4.x.x",
-        "items": "2.x.x",
-        "joi": "10.x.x",
-        "lru-cache": "4.1.x"
-      },
-      "dependencies": {
-        "joi": {
-          "version": "10.6.0",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
-          "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
-          "requires": {
-            "hoek": "4.x.x",
-            "isemail": "2.x.x",
-            "items": "2.x.x",
-            "topo": "2.x.x"
-          }
-        }
-      }
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -3218,16 +3235,6 @@
       "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
       "dev": true
     },
-    "iron": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/iron/-/iron-4.0.5.tgz",
-      "integrity": "sha1-TwQszri5c480a1mqc0yDqJvDFCg=",
-      "requires": {
-        "boom": "5.x.x",
-        "cryptiles": "3.x.x",
-        "hoek": "4.x.x"
-      }
-    },
     "is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -3235,6 +3242,23 @@
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "is-alphabetical": {
@@ -3275,9 +3299,10 @@
       }
     },
     "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+      "dev": true
     },
     "is-callable": {
       "version": "1.1.4",
@@ -3301,6 +3326,23 @@
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "is-date-object": {
@@ -3396,6 +3438,23 @@
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "is-obj": {
@@ -3510,11 +3569,6 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
-    },
-    "isemail": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
-      "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY="
     },
     "isexe": {
       "version": "2.0.0",
@@ -3649,31 +3703,6 @@
         "handlebars": "^4.1.2"
       }
     },
-    "items": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/items/-/items-2.1.2.tgz",
-      "integrity": "sha512-kezcEqgB97BGeZZYtX/MA8AG410ptURstvnz5RAgyFZ8wQFPMxHY8GpTq+/ZHKT3frSlIthUq7EvLt9xn3TvXg=="
-    },
-    "joi": {
-      "version": "11.4.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-11.4.0.tgz",
-      "integrity": "sha512-O7Uw+w/zEWgbL6OcHbyACKSj0PkQeUgmehdoXVSxt92QFCq4+1390Rwh5moI2K/OgC7D8RHRZqHZxT2husMJHA==",
-      "requires": {
-        "hoek": "4.x.x",
-        "isemail": "3.x.x",
-        "topo": "2.x.x"
-      },
-      "dependencies": {
-        "isemail": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
-          "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
-          "requires": {
-            "punycode": "2.x.x"
-          }
-        }
-      }
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3762,12 +3791,10 @@
       }
     },
     "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "requires": {
-        "is-buffer": "^1.1.5"
-      }
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "dev": true
     },
     "known-css-properties": {
       "version": "0.13.0",
@@ -3783,12 +3810,6 @@
       "requires": {
         "package-json": "^4.0.0"
       }
-    },
-    "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "optional": true
     },
     "lcid": {
       "version": "2.0.0",
@@ -3869,12 +3890,6 @@
       "requires": {
         "chalk": "^2.0.1"
       }
-    },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "optional": true
     },
     "longest-streak": {
       "version": "2.0.3",
@@ -4113,14 +4128,6 @@
         "regex-not": "^1.0.0",
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        }
       }
     },
     "mime-db": {
@@ -4142,15 +4149,6 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
-    },
-    "mimos": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/mimos/-/mimos-3.0.3.tgz",
-      "integrity": "sha1-uRCQcq03jCty9qAQHEPd+ys2ZB8=",
-      "requires": {
-        "hoek": "4.x.x",
-        "mime-db": "1.x.x"
-      }
     },
     "minimatch": {
       "version": "3.0.4",
@@ -4245,35 +4243,6 @@
         "yargs-unparser": "1.5.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "cliui": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
-          },
-          "dependencies": {
-            "string-width": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-              "dev": true,
-              "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
-              }
-            }
-          }
-        },
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -4297,28 +4266,6 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^4.1.0"
-              }
-            }
-          }
-        },
         "supports-color": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
@@ -4326,25 +4273,6 @@
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
-          }
-        },
-        "yargs": {
-          "version": "13.2.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
-          "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
-          "dev": true,
-          "requires": {
-            "cliui": "^4.0.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "os-locale": "^3.1.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^13.0.0"
           }
         }
       }
@@ -4385,14 +4313,6 @@
         "regex-not": "^1.0.0",
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.1"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        }
       }
     },
     "natural-compare": {
@@ -4416,15 +4336,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
-    },
-    "nigel": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/nigel/-/nigel-2.0.2.tgz",
-      "integrity": "sha1-k6GGb7DFLYc5CqdeKxYfS1x15bE=",
-      "requires": {
-        "hoek": "4.x.x",
-        "vise": "2.x.x"
-      }
     },
     "node-environment-flags": {
       "version": "1.0.5",
@@ -4567,29 +4478,6 @@
         "yargs-parser": "^13.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
-        },
-        "cliui": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-          "dev": true,
-          "requires": {
-            "string-width": "^3.1.0",
-            "strip-ansi": "^5.2.0",
-            "wrap-ansi": "^5.1.0"
-          }
-        },
         "make-dir": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -4605,68 +4493,6 @@
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
           "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.0",
-            "string-width": "^3.0.0",
-            "strip-ansi": "^5.0.0"
-          }
-        },
-        "yargs": {
-          "version": "13.2.4",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
-          "integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
-          "dev": true,
-          "requires": {
-            "cliui": "^5.0.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "os-locale": "^3.1.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^13.1.0"
-          },
-          "dependencies": {
-            "yargs-parser": {
-              "version": "13.1.0",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.0.tgz",
-              "integrity": "sha512-Yq+32PrijHRri0vVKQEm+ys8mbqWjLiwQkMFNXEENutzLPP0bE4Lcd4iA3OQY5HF+GD3xXxf0MEHb8E4/SA3AA==",
-              "dev": true,
-              "requires": {
-                "camelcase": "^5.0.0",
-                "decamelize": "^1.2.0"
-              }
-            }
-          }
         }
       }
     },
@@ -4694,6 +4520,21 @@
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
+          }
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -4971,18 +4812,6 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
-    "pez": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/pez/-/pez-2.1.5.tgz",
-      "integrity": "sha1-XsLMYlAMw+tCNtSkFM9aF7XrUAc=",
-      "requires": {
-        "b64": "3.x.x",
-        "boom": "5.x.x",
-        "content": "3.x.x",
-        "hoek": "4.x.x",
-        "nigel": "2.x.x"
-      }
-    },
     "picomatch": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
@@ -5002,29 +4831,6 @@
       "dev": true,
       "requires": {
         "find-up": "^3.0.0"
-      }
-    },
-    "podium": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/podium/-/podium-1.3.0.tgz",
-      "integrity": "sha512-ZIujqk1pv8bRZNVxwwwq0BhXilZ2udycQT3Kp8ah3f3TcTmVg7ILJsv/oLf47gRa2qeiP584lNq+pfvS9U3aow==",
-      "requires": {
-        "hoek": "4.x.x",
-        "items": "2.x.x",
-        "joi": "10.x.x"
-      },
-      "dependencies": {
-        "joi": {
-          "version": "10.6.0",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
-          "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
-          "requires": {
-            "hoek": "4.x.x",
-            "isemail": "2.x.x",
-            "items": "2.x.x",
-            "topo": "2.x.x"
-          }
-        }
       }
     },
     "posix-character-classes": {
@@ -5221,7 +5027,8 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "qs": {
       "version": "6.5.2",
@@ -5427,7 +5234,8 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
     },
     "replace-ext": {
       "version": "1.0.0",
@@ -5511,15 +5319,6 @@
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
-    },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "optional": true,
-      "requires": {
-        "align-text": "^0.1.1"
-      }
     },
     "rimraf": {
       "version": "2.6.3",
@@ -5624,28 +5423,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-    },
-    "shot": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/shot/-/shot-3.4.2.tgz",
-      "integrity": "sha1-Hlw/bysmZJrcQvfrNQIUpaApHWc=",
-      "requires": {
-        "hoek": "4.x.x",
-        "joi": "10.x.x"
-      },
-      "dependencies": {
-        "joi": {
-          "version": "10.6.0",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
-          "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
-          "requires": {
-            "hoek": "4.x.x",
-            "isemail": "2.x.x",
-            "items": "2.x.x",
-            "topo": "2.x.x"
-          }
-        }
-      }
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -5775,12 +5552,6 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
         }
       }
     },
@@ -5791,14 +5562,23 @@
       "dev": true,
       "requires": {
         "kind-of": "^3.2.0"
-      }
-    },
-    "somever": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/somever/-/somever-1.0.1.tgz",
-      "integrity": "sha512-PCDMBcega4n7wuBUKmkiXidF3cOwtHHGg2qJYl0Rkw7StZqORoCgqce7HUuWNta/NAiQhwLDezNnTANxEWPCGA==",
-      "requires": {
-        "hoek": "4.x.x"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "source-map": {
@@ -5919,40 +5699,6 @@
       "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.2.tgz",
       "integrity": "sha512-8LpelPGR0qQM4PnfLiplOQNJcIN1/r2Gy0xKB2zKnIW2YzPMt2sR4I/+gtPjhN7Svh9kw+zqEg2SFwpBO9iNiw==",
       "dev": true
-    },
-    "statehood": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/statehood/-/statehood-5.0.4.tgz",
-      "integrity": "sha512-6/feFLqqHylvA/dHwJA0DgXvbEcKgbhRUeljsuu6+cIr8PO88nax7Wc+celZlPTncqT2arsxXL8P329Q1yfe9Q==",
-      "requires": {
-        "boom": "5.x.x",
-        "bourne": "1.x.x",
-        "cryptiles": "3.x.x",
-        "hoek": "4.x.x",
-        "iron": "4.x.x",
-        "items": "2.x.x",
-        "joi": "12.x.x"
-      },
-      "dependencies": {
-        "isemail": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
-          "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
-          "requires": {
-            "punycode": "2.x.x"
-          }
-        },
-        "joi": {
-          "version": "12.0.0",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-12.0.0.tgz",
-          "integrity": "sha512-z0FNlV4NGgjQN1fdtHYXf5kmgludM65fG/JlXzU6+rwkt9U5UWuXVYnXa2FpK0u6+qBuCmrm5byPNuiiddAHvQ==",
-          "requires": {
-            "hoek": "4.x.x",
-            "isemail": "3.x.x",
-            "topo": "2.x.x"
-          }
-        }
-      }
     },
     "static-extend": {
       "version": "0.1.2",
@@ -6237,19 +5983,6 @@
         }
       }
     },
-    "subtext": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/subtext/-/subtext-5.0.1.tgz",
-      "integrity": "sha512-zH/jaUKJ/bkrTpEe3zuTFIRnqAwv5xcGpXA2JaxEc30KRAT4k78jZnRqM45snjBSZAuvpI8chRUh1VZprcUVfw==",
-      "requires": {
-        "boom": "5.x.x",
-        "bourne": "1.x.x",
-        "content": "3.x.x",
-        "hoek": "4.x.x",
-        "pez": "2.x.x",
-        "wreck": "12.x.x"
-      }
-    },
     "sugarss": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-2.0.0.tgz",
@@ -6409,6 +6142,23 @@
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "to-regex": {
@@ -6431,14 +6181,6 @@
       "requires": {
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
-      }
-    },
-    "topo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
-      "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
-      "requires": {
-        "hoek": "4.x.x"
       }
     },
     "touch": {
@@ -6537,12 +6279,6 @@
         "commander": "~2.20.0",
         "source-map": "~0.6.1"
       }
-    },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "optional": true
     },
     "undefsafe": {
       "version": "2.0.2",
@@ -6837,14 +6573,6 @@
         "replace-ext": "1.0.0",
         "unist-util-stringify-position": "^1.0.0",
         "vfile-message": "^1.0.0"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
-          "dev": true
-        }
       }
     },
     "vfile-location": {
@@ -6860,46 +6588,6 @@
       "dev": true,
       "requires": {
         "unist-util-stringify-position": "^1.1.1"
-      }
-    },
-    "vise": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/vise/-/vise-2.0.2.tgz",
-      "integrity": "sha1-awjo+0y3bjpQzW3Q7DczjoEaDTk=",
-      "requires": {
-        "hoek": "4.x.x"
-      }
-    },
-    "vision": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/vision/-/vision-4.1.1.tgz",
-      "integrity": "sha1-4bYSstLi8gMQoDkpD9SdUSSPgto=",
-      "requires": {
-        "boom": "4.x.x",
-        "hoek": "4.x.x",
-        "items": "2.x.x",
-        "joi": "10.x.x"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-          "requires": {
-            "hoek": "4.x.x"
-          }
-        },
-        "joi": {
-          "version": "10.6.0",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
-          "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
-          "requires": {
-            "hoek": "4.x.x",
-            "isemail": "2.x.x",
-            "items": "2.x.x",
-            "topo": "2.x.x"
-          }
-        }
       }
     },
     "which": {
@@ -6933,12 +6621,6 @@
       "requires": {
         "string-width": "^2.1.1"
       }
-    },
-    "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "optional": true
     },
     "wordwrap": {
       "version": "0.0.3",
@@ -6998,15 +6680,6 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
-    "wreck": {
-      "version": "12.5.1",
-      "resolved": "https://registry.npmjs.org/wreck/-/wreck-12.5.1.tgz",
-      "integrity": "sha512-l5DUGrc+yDyIflpty1x9XuMj1ehVjC/dTbF3/BasOO77xk0EdEa4M/DuOY8W88MQDAD0fEDqyjc8bkIMHd2E9A==",
-      "requires": {
-        "boom": "5.x.x",
-        "hoek": "4.x.x"
-      }
-    },
     "write": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
@@ -7057,15 +6730,50 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-      "optional": true,
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
+      "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
+      "dev": true,
       "requires": {
-        "camelcase": "^1.0.2",
-        "cliui": "^2.1.0",
-        "decamelize": "^1.0.0",
-        "window-size": "0.1.0"
+        "cliui": "^4.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "os-locale": "^3.1.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
     },
     "yargs-parser": {
@@ -7076,14 +6784,6 @@
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
-        }
       }
     },
     "yargs-unparser": {
@@ -7097,23 +6797,6 @@
         "yargs": "^12.0.5"
       },
       "dependencies": {
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
-        },
-        "cliui": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
-          }
-        },
         "get-caller-file": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -29,14 +29,13 @@
     "watch": "nodemon --ext css,js,html --exec \"npm run server\""
   },
   "dependencies": {
+    "@hapi/hapi": "^18.3.1",
+    "@hapi/inert": "^5.2.0",
+    "@hapi/vision": "^5.5.2",
     "cross-env": "^5.2.0",
     "handlebars": "^4.1.2",
     "handlebars-helper-sri": "0.0.0",
-    "hapi": "^16.6.3",
-    "hapi-sitemap": "^1.0.3",
-    "inert": "^4.2.1",
-    "sri-toolbox": "^0.2.0",
-    "vision": "^4.1.1"
+    "sri-toolbox": "^0.2.0"
   },
   "devDependencies": {
     "coveralls": "^3.0.3",

--- a/test/generate.js
+++ b/test/generate.js
@@ -8,7 +8,7 @@ const generate = require('../lib/generate');
 
 // Ideally we should find a way to test this without using the network
 describe('generate()', () => {
-  it('js', (done) => {
+  it('js', async() => {
     const resource = {
       url: 'https://code.jquery.com/jquery-1.11.2.min.js',
       algorithms: ['sha384']
@@ -21,14 +21,12 @@ describe('generate()', () => {
       integrity: 'sha384-Pn+PczAsODRZ2PiGg0IheRROpP7lXO1NTIjiPo6cca8TliBvaeil42fobhzvZd74',
       eligibility: []
     };
+    const result = await generate(resource);
 
-    generate(resource, (data) => {
-      assert.deepEqual(data, expect);
-      done();
-    });
+    assert.deepEqual(result, expect);
   });
 
-  it('css', (done) => {
+  it('css', async() => {
     const resource = {
       url: 'https://code.jquery.com/ui/1.11.3/themes/black-tie/jquery-ui.css',
       algorithms: ['sha384']
@@ -41,14 +39,12 @@ describe('generate()', () => {
       integrity: 'sha384-w/LBTbFO0P4C3wi1uA2RpBjIEBMRuH15ue80rElDXquOVM6x7Cw3nsOqy7vSBid9',
       eligibility: []
     };
+    const result = await generate(resource);
 
-    generate(resource, (data) => {
-      assert.deepEqual(data, expect);
-      done();
-    });
+    assert.deepEqual(result, expect);
   });
 
-  it('404', (done) => {
+  it('404', async() => {
     const resource = {
       url: 'https://code.jquery.com/jquery-1.11.2-notfound.min.js',
       algorithms: ['sha384']
@@ -57,10 +53,8 @@ describe('generate()', () => {
       success: false,
       status: 404
     };
+    const result = await generate(resource);
 
-    generate(resource, (data) => {
-      assert.deepEqual(data, expect);
-      done();
-    });
+    assert.deepEqual(result, expect);
   });
 });

--- a/test/generateElement.js
+++ b/test/generateElement.js
@@ -8,74 +8,60 @@ const generateElement = require('../lib/generateElement');
 
 // Ideally we should find a way to test this without using the network
 describe('generateElement()', () => {
-  it('non-CORS', (done) => {
+  it('non-CORS', async() => {
     const url = 'https://www.google-analytics.com/ga.js';
     const expect = 'Error: this resource is not eligible for integrity checks. See https://enable-cors.org/server.html';
+    const result = await generateElement(url, 'sha384');
 
-    generateElement(url, 'sha384', (data) => {
-      assert.deepEqual(data, expect);
-      done();
-    });
+    assert.deepEqual(result, expect);
   });
 
-  it('css', (done) => {
+  it('css', async() => {
     const url = 'https://code.jquery.com/ui/1.11.3/themes/black-tie/jquery-ui.css';
     const expect = '<link rel="stylesheet" href="https://code.jquery.com/ui/1.11.3/themes/black-tie/jquery-ui.css" integrity="sha384-w/LBTbFO0P4C3wi1uA2RpBjIEBMRuH15ue80rElDXquOVM6x7Cw3nsOqy7vSBid9" crossorigin="anonymous">';
+    const result = await generateElement(url, 'sha384');
 
-    generateElement(url, 'sha384', (data) => {
-      assert.deepEqual(data, expect);
-      done();
-    });
+    assert.deepEqual(result, expect);
   });
 
-  it('css (http)', (done) => {
+  it('css (http)', async() => {
     const url = 'http://cdn.ckeditor.com/4.9.2/standard/ckeditor.js';
     const expect = '<script src="http://cdn.ckeditor.com/4.9.2/standard/ckeditor.js" integrity="sha384-5z5Xzy2KLn1l/Q0rWj1TYy+VXyLHqWrwDKCCLG++mTDqiJr4uRbP9f37MKAm4ca8" crossorigin="anonymous"></script>';
+    const result = await generateElement(url, 'sha384');
 
-    generateElement(url, 'sha384', (data) => {
-      assert.deepEqual(data, expect);
-      done();
-    });
+    assert.deepEqual(result, expect);
   });
 
-  it('js', (done) => {
+  it('js', async() => {
     const url = 'https://code.jquery.com/jquery-1.11.2.min.js';
     const expect = '<script src="https://code.jquery.com/jquery-1.11.2.min.js" integrity="sha384-Pn+PczAsODRZ2PiGg0IheRROpP7lXO1NTIjiPo6cca8TliBvaeil42fobhzvZd74" crossorigin="anonymous"></script>';
+    const result = await generateElement(url, 'sha384');
 
-    generateElement(url, 'sha384', (data) => {
-      assert.deepEqual(data, expect);
-      done();
-    });
+    assert.deepEqual(result, expect);
   });
 
-  it('404', (done) => {
+  it('404', async() => {
     const url = 'https://code.jquery.com/jquery-1.11.2-notfound.min.js';
     const expect = 'Error: fetching the resource returned a 404 error code.';
+    const result = await generateElement(url, 'sha384');
 
-    generateElement(url, 'sha384', (data) => {
-      assert.deepEqual(data, expect);
-      done();
-    });
+    assert.deepEqual(result, expect);
   });
 
-  it('unrecognized content-type', (done) => {
+  it('unrecognized content-type', async() => {
     const url = 'https://stackpath.bootstrapcdn.com/twitter-bootstrap/2.0.4/img/glyphicons-halflings.png';
     const expect = `<!-- Warning: Unrecognized content-type. Are you sure this is the right resource? -->
 <script src="https://stackpath.bootstrapcdn.com/twitter-bootstrap/2.0.4/img/glyphicons-halflings.png" integrity="sha384-c9lMzzhAB7gpgb7lXNeNoigdEkAKXMNRWTRoSODIc/tNrxSItcZOOSP+xtG2De5i" crossorigin="anonymous"></script>`;
+    const result = await generateElement(url, 'sha384');
 
-    generateElement(url, 'sha384', (data) => {
-      assert.deepEqual(data, expect);
-      done();
-    });
+    assert.deepEqual(result, expect);
   });
 
-  it('bad scheme', (done) => {
+  it('bad scheme', async() => {
     const url = 'ftp://code.jquery.com/jquery-1.11.2.min.js';
     const expect = 'Error: fetching the resource returned an unexpected error.';
+    const result = await generateElement(url, 'sha384');
 
-    generateElement(url, 'sha384', (data) => {
-      assert.deepEqual(data, expect);
-      done();
-    });
+    assert.deepEqual(result, expect);
   });
 });


### PR DESCRIPTION
Fixes #212 

Preview with `?w=1` https://github.com/mozilla/srihash.org/pull/229/files?utf8=%E2%9C%93&diff=unified&w=1.

- [x] Fix the `POST` route
- [x] See if the sitemap plugin works, currently I removed it. Doesn't seem to work with the newer Hapi.
- [ ] Convert the remaining callback-based functions to Promises
- [ ] Use `reject` in the new Promise-based functions
