### PR TITLE
Remove protocol-relative and schemeless code

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -21,20 +21,8 @@ const secureHosts = require('./secureHosts.json');
  * @return {string} processed URL
  */
 const upgradeToHttps = (urlString) => {
-  // Add a scheme to scheme-less URLs
-  const isRelative = Boolean(urlString.match(/^\/\//));
-
-  if (isRelative) {
-    urlString = `https:${urlString}`;
-  }
-
   // Prepend http for protocol-less URL's
-  let urlObject = url.parse(urlString);
-
-  if (!urlObject.protocol && !isRelative) {
-    urlString = `http://${urlString}`;
-    urlObject = url.parse(urlString);
-  }
+  const urlObject = url.parse(urlString);
 
   // Upgrade http protocol to https, if host is on the secureHosts list
   if (urlObject.protocol === 'http:' && secureHosts.includes(urlObject.hostname)) {
@@ -58,6 +46,10 @@ const upgradeToHttps = (urlString) => {
 const moduleForProtocol = (urlString) => {
   const urlObject = url.parse(urlString);
 
+  if (!urlObject.protocol) {
+    return false;
+  }
+
   if (urlObject.protocol === 'https:') {
     return https;
   }
@@ -65,8 +57,6 @@ const moduleForProtocol = (urlString) => {
   if (urlObject.protocol === 'http:') {
     return http;
   }
-
-  return false;
 };
 
 /**

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -25,31 +25,10 @@ describe('upgradeToHttps()', () => {
     });
   });
 
-  describe('URLs', () => {
-    it('Schemeless', () => {
-      const schemelessUnknownUrl = helpers.upgradeToHttps('example.com/script.js');
-      assert.strictEqual(schemelessUnknownUrl, 'http://example.com/script.js');
-      const schemelessKnownUrl = helpers.upgradeToHttps('code.jquery.com/script.js');
-      assert.strictEqual(schemelessKnownUrl, 'https://code.jquery.com/script.js');
-    });
-
-    it('Relative', () => {
-      const relativeUnknownUrl = helpers.upgradeToHttps('//example.com/script.js');
-      assert.strictEqual(relativeUnknownUrl, 'https://example.com/script.js');
-      const relativeKnownUrl = helpers.upgradeToHttps('//code.jquery.com/script.js');
-      assert.strictEqual(relativeKnownUrl, 'https://code.jquery.com/script.js');
-    });
-  });
-
   describe('Invalid URLs', () => {
     it('Invalid scheme', () => {
       const ftpScheme = helpers.upgradeToHttps('ftp://example.com/script.js');
       assert.strictEqual(ftpScheme, false);
-    });
-
-    it('Bare hostname', () => {
-      const bareHostname = helpers.upgradeToHttps('foobar');
-      assert.strictEqual(bareHostname, 'http://foobar/');
     });
   });
 });
@@ -287,7 +266,7 @@ describe('generateElement()', () => {
   })();
 
   ((result) => {
-    const url = 'code.jquery.com/ui/1.11.3/themes/black-tie/jquery-ui.css';
+    const url = 'https://code.jquery.com/ui/1.11.3/themes/black-tie/jquery-ui.css';
     const expect = '<link rel="stylesheet" href="https://code.jquery.com/ui/1.11.3/themes/black-tie/jquery-ui.css" integrity="sha384-w/LBTbFO0P4C3wi1uA2RpBjIEBMRuH15ue80rElDXquOVM6x7Cw3nsOqy7vSBid9" crossorigin="anonymous">';
 
     before((done) => {
@@ -319,7 +298,7 @@ describe('generateElement()', () => {
   })();
 
   ((result) => {
-    const url = 'code.jquery.com/jquery-1.11.2.min.js';
+    const url = 'https://code.jquery.com/jquery-1.11.2.min.js';
     const expect = '<script src="https://code.jquery.com/jquery-1.11.2.min.js" integrity="sha384-Pn+PczAsODRZ2PiGg0IheRROpP7lXO1NTIjiPo6cca8TliBvaeil42fobhzvZd74" crossorigin="anonymous"></script>';
 
     before((done) => {


### PR DESCRIPTION
Since we use `input type="url">` on the frontend, this cannot happen.