### PR TITLE
Replace `url.parse` with the URL constructor.

### DIFF
--- a/lib/fetchResource.js
+++ b/lib/fetchResource.js
@@ -4,7 +4,7 @@
 
 'use strict';
 
-const url = require('url');
+const { URL } = require('url');
 const zlib = require('zlib');
 const moduleForProtocol = require('./moduleForProtocol');
 const processResource = require('./processResource');
@@ -24,10 +24,10 @@ const fetchResource = (resourceUrl, cb) => {
     return cb(false);
   }
 
-  const urlObject = url.parse(resourceUrl);
+  const urlObject = new URL(resourceUrl);
   const options = {
     hostname: urlObject.hostname,
-    path: urlObject.path,
+    path: urlObject.pathname,
     headers: {
       Origin: 'https://www.srihash.org/'
     }

--- a/lib/guessResourceType.js
+++ b/lib/guessResourceType.js
@@ -5,7 +5,7 @@
 'use strict';
 
 const path = require('path');
-const url = require('url');
+const { URL } = require('url');
 const resourceTypes = require('./data/resourceTypes');
 
 /**
@@ -28,7 +28,7 @@ const guessResourceType = (resource) => {
   }
 
   // Match against file extensions
-  const ext = path.extname(url.parse(resource.url).pathname)
+  const ext = path.extname(new URL(resource.url).pathname)
     .replace('.', '')
     .toLowerCase();
 

--- a/lib/moduleForProtocol.js
+++ b/lib/moduleForProtocol.js
@@ -6,7 +6,7 @@
 
 const http = require('http');
 const https = require('https');
-const url = require('url');
+const { URL } = require('url');
 
 /**
  * Choose corresponding module (http or https) for downloading a resource.
@@ -15,7 +15,7 @@ const url = require('url');
  * @return {Object} http or https module
  */
 const moduleForProtocol = (urlString) => {
-  const urlObject = url.parse(urlString);
+  const urlObject = new URL(urlString);
 
   if (!urlObject.protocol) {
     return false;

--- a/lib/upgradeToHttps.js
+++ b/lib/upgradeToHttps.js
@@ -15,7 +15,7 @@ const secureHosts = require('./data/secureHosts');
  */
 const upgradeToHttps = (urlString) => {
   // Prepend http for protocol-less URL's
-  const urlObject = url.parse(urlString);
+  const urlObject = new url.URL(urlString);
 
   // Upgrade http protocol to https, if host is on the secureHosts list
   if (urlObject.protocol === 'http:' && secureHosts.includes(urlObject.hostname)) {


### PR DESCRIPTION
Closes #231, fixes #215 

I hope we don't miss any cases in our tests, otherwise everything seems to work :)

BTW when we switch to Node.js 10, we can drop the `url` requires since it's built-in.