### PR TITLE
Switch to Node.js 10.x.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - "8"
+  - "10"
 
 script:
   - npm run travis

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is the code behind the <https://www.srihash.org/> website. It generates [su
 
 ## Install
 
-You'll need node.js 8.x and npm to run the server.
+You'll need Node.js 10.x and npm to run the server.
 
 Clone the git repository and install dependencies:
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "stylelint-config-standard": "^18.3.0"
   },
   "engines": {
-    "node": ">=8"
+    "node": "10.x"
   },
   "nyc": {
     "include": [


### PR DESCRIPTION
@mozfreddyb not sure how Heroku picks up the Node.js version, so if there's something more we need to do let me know.

Fixes #273.

Before this, Heroku was using the latest Node.js version, 12.x at the time of writing.