### PR TITLE
Add hapi-require-https.

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,11 @@
 {
   "name": "srihash",
   "scripts": {},
-  "env": {},
+  "env": {
+    "SRIHASH_FORCE_SSL": {
+      "description": "Force SSL redirection",
+      "value": "true"
+    }
+  },
   "addons": []
 }

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ const PLUGINS = [vision, inert];
       }
     });
 
-    if (process.env.NODE_ENV === 'production') {
+    if (process.env.SRIHASH_FORCE_SSL === 'true') {
       PLUGINS.push(requireHttps);
     }
 

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const vision = require('@hapi/vision');
 const inert = require('@hapi/inert');
 const handlebarsHelperSRI = require('handlebars-helper-sri');
 const handlebarsPartialFile = require('handlebars-partial-file');
+const requireHttps = require('hapi-require-https');
 const generate = require('./lib/generate');
 const generateElement = require('./lib/generateElement');
 
@@ -26,6 +27,7 @@ hbsPartialFile.registerDirectory('badge', 'svg');
 // eslint-disable-next-line quotes
 const CSP_HEADER = "default-src 'none'; base-uri 'none'; form-action 'self'; frame-src 'self'; frame-ancestors 'self'; img-src 'self'; manifest-src 'self'; style-src 'self'";
 const REFERRER_HEADER = 'no-referrer, strict-origin-when-cross-origin';
+const PLUGINS = [vision, inert];
 
 (async() => {
   try {
@@ -43,7 +45,11 @@ const REFERRER_HEADER = 'no-referrer, strict-origin-when-cross-origin';
       }
     });
 
-    await server.register([vision, inert]);
+    if (process.env.NODE_ENV === 'production') {
+      PLUGINS.push(requireHttps);
+    }
+
+    await server.register(PLUGINS);
 
     server.views({
       engines: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3263,6 +3263,11 @@
         "handlebars": "^4.0.11"
       }
     },
+    "hapi-require-https": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hapi-require-https/-/hapi-require-https-4.0.0.tgz",
+      "integrity": "sha512-dT5nLoFtro3ltCMmwkt29VnZRDrKgPfQN5ZOKdukrIxKMh3aZ1f4LR7dbDHfIVIBMmQiZoMFqunDv5t1oLKERw=="
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "handlebars": "^4.4.3",
     "handlebars-helper-sri": "0.0.0",
     "handlebars-partial-file": "^1.0.0",
+    "hapi-require-https": "^4.0.0",
     "node-fetch": "^2.6.0",
     "sri-toolbox": "^0.2.0"
   },


### PR DESCRIPTION
Supersedes #184.

This is only tested locally. We could add an extra env var on Heroku and rely on it instead of `NODE_ENV`.