### PR TITLE
Update fetchResource and processResource to use async/await instead of callbacks

### DIFF
--- a/lib/fetchResource.js
+++ b/lib/fetchResource.js
@@ -12,27 +12,24 @@ const upgradeToHttps = require('./upgradeToHttps');
  * Download the resource
  *
  * @param {string} resourceUrl - The URL to fetch
- * @param {Function} cb - callback
  * @return {Object.XMLHttpRequest} request object
  */
-const fetchResource = (resourceUrl, cb) => {
+const fetchResource = async(resourceUrl) => {
   resourceUrl = upgradeToHttps(resourceUrl);
 
   if (!resourceUrl) {
-    return cb(false);
+    return false;
   }
 
-  fetch(resourceUrl, {
+  const response = await fetch(resourceUrl, {
     headers: {
       Origin: 'https://www.srihash.org/'
     }
-  })
-    .then((response) => {
-      response.buffer()
-        .then((data) => {
-          processResource(data, response, response.url, cb);
-        });
-    });
+  });
+
+  const data = await response.buffer();
+
+  return processResource(data, response, response.url);
 };
 
 module.exports = fetchResource;

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -18,7 +18,7 @@ const fetchResource = require('./fetchResource');
  * @return {Promise}
  */
 const generate = async(options) => {
-  if (typeof options.algorithms === 'string') {
+  if (!Array.isArray(options.algorithms)) {
     options.algorithms = [options.algorithms];
   }
 

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -17,44 +17,42 @@ const fetchResource = require('./fetchResource');
  * @param {string} options.url - Resource URL
  * @return {Promise}
  */
-const generate = (options) => {
-  return new Promise((resolve) => {
-    if (typeof options.algorithms === 'string') {
-      options.algorithms = [options.algorithms];
-    }
+const generate = async(options) => {
+  if (typeof options.algorithms === 'string') {
+    options.algorithms = [options.algorithms];
+  }
 
-    fetchResource(options.url, (resource) => {
-      if (!resource) {
-        return resolve({
-          success: false,
-          status: 0
-        });
-      }
+  const resource = await fetchResource(options.url);
 
-      if (resource.status !== 200) {
-        return resolve(resource);
-      }
+  if (!resource) {
+    return {
+      success: false,
+      status: 0
+    };
+  }
 
-      const sri = sriToolbox.generate({
-        algorithms: options.algorithms,
-        full: true
-      }, resource.data);
+  if (resource.status !== 200) {
+    return resource;
+  }
 
-      const contentType = getResourceTypeFromContentTypeHeader(resource.ct);
+  const sri = sriToolbox.generate({
+    algorithms: options.algorithms,
+    full: true
+  }, resource.data);
 
-      return resolve({
-        success: true,
-        status: resource.status,
-        url: resource.url,
-        type: guessResourceType({
-          url: resource.url,
-          ct: contentType
-        }),
-        integrity: sri.integrity,
-        eligibility: resource.eligibility
-      });
-    });
-  });
+  const contentType = getResourceTypeFromContentTypeHeader(resource.ct);
+
+  return {
+    success: true,
+    status: resource.status,
+    url: resource.url,
+    type: guessResourceType({
+      url: resource.url,
+      ct: contentType
+    }),
+    integrity: sri.integrity,
+    eligibility: resource.eligibility
+  };
 };
 
 module.exports = generate;

--- a/lib/processResource.js
+++ b/lib/processResource.js
@@ -12,25 +12,24 @@ const eligibility = require('./eligibility');
  * @param {string} data
  * @param {Object} response
  * @param {string} resourceUrl - Resource URL
- * @param {Function} cb - callback
- * @return {Function.cb}
+ * @return {Object.XMLHttpRequest}
  */
-const processResource = (data, response, resourceUrl, cb) => {
+const processResource = (data, response, resourceUrl) => {
   if (response.status !== 200) {
-    return cb({
+    return {
       success: false,
       status: response.status
-    });
+    };
   }
 
-  return cb({
+  return {
     success: true,
     status: response.status,
     url: resourceUrl,
     eligibility: eligibility(response),
     data,
     ct: response.headers.get('content-type')
-  });
+  };
 };
 
 module.exports = processResource;


### PR DESCRIPTION
Per #272, update parts of the code to not use callbacks. 

I chose to follow the async/await pattern used by the Hapi request handlers in index.js instead of returning Promise objects. Happy to switch to using promises if that is preferred.