### PR TITLE
input: specify `spellcheck="false"`

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -42,7 +42,7 @@
           <h1>SRI Hash Generator</h1>
           <label for="url">Enter the URL of the resource you wish to use:</label>
           <form method="POST" action="/hash" target="sriSnippet">
-            <input id="url" name="url" type="url" value="" placeholder="Resource URL" required autofocus>
+            <input id="url" name="url" type="url" value="" placeholder="Resource URL" required autofocus spellcheck="false">
             <input name="algorithms" type="hidden" value="sha384">
             <input type="submit" value="Hash!">
           </form>


### PR DESCRIPTION
This doesn't seem to be a part of any spec but it does prevent Chrome from spellchecking the URL.

@mozfreddyb I only tested Chrome on Windows. I'm not sure how other browsers/OS'es may behave like Safari or macOS.