### PR TITLE
Refine URL validation check

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,7 +3,7 @@
 function getErrorText(url) {
   const printableURL = encodeURI(url);
 
-  if (url.startsWith("http")) {
+  if (url.startsWith("http://") || url.startsWith("https://")) {
     return `
     Could not fetch from URL <em><a href="${printableURL}">${printableURL}</a></em>.<br>
     Your issue could be one of the following:


### PR DESCRIPTION
A small suggestion. Feel free to ignore/reject.

Currently a URL starting with (for example) `'httpps://'` would be considered valid.  This commit makes the check more strict.