### PR TITLE
Fix missing Byte-Order-Mark issue

### DIFF
--- a/app.js
+++ b/app.js
@@ -41,10 +41,8 @@ function digestName(hashAlgorithm) {
   }
 }
 
-async function hashText(message, algorithm) {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(message);
-  const digest = await crypto.subtle.digest(digestName(algorithm), data);
+async function hashText(buffer, algorithm) {
+  const digest = await crypto.subtle.digest(digestName(algorithm), buffer);
 
   return digest;
 }
@@ -64,8 +62,8 @@ function parseContentType(type) {
   return 'script';
 }
 
-async function integrityMetadata(text, algorithm) {
-  const hashBuffer = await hashText(text, algorithm); // Array Buffer
+async function integrityMetadata(buffer, algorithm) {
+  const hashBuffer = await hashText(buffer, algorithm);
   const base64string = btoa(
     String.fromCharCode(...new Uint8Array(hashBuffer))
   );
@@ -144,9 +142,9 @@ async function formSubmit(event) {
     if (response.status === 200) {
       const type = response.headers.get("content-type");
       const contentType = parseContentType(type);
-      const text = await response.text();
+      const buffer = await response.arrayBuffer();
       const hashAlgorithm = hashEl.value;
-      const integrity = await integrityMetadata(text, hashAlgorithm);
+      const integrity = await integrityMetadata(buffer, hashAlgorithm);
 
       displayResult(resultDiv, url, contentType, integrity);
     } else {


### PR DESCRIPTION
Previously, the code would operate on a response text and encode it into
UTF-8 using the TextEncoder API. This removes the byte-order-mark and
results in an incorrect hash.

The fix is quite easy: The fetch response can already return an
ArrayBuffer and hashing the bytes skips this error-prone operation
completely. For readability's sake, the variables "text" have been
renamed too.