### PR TITLE
updated git link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ This is an example workflow to make it easier to submit Pull Requests. Imagine y
 2. The clone the upstream (as origin) and add your own repo as a remote:
 
     ```sh
-    $ git clone git://github.com/mozilla/srihash.org.git
+    $ git clone https://github.com/mozilla/srihash.org.git
     $ cd srihash.org
     $ git remote add user1 git@github.com:user1/srihash.org.git
     ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You'll need Node.js 10.x and npm for linting and a local server for testing
 Clone the git repository and install dependencies:
 
 ```shell
-git clone git://github.com/mozilla/srihash.org.git
+git clone https://github.com/mozilla/srihash.org.git
 cd srihash.org
 npm install
 ```


### PR DESCRIPTION
The `git://` URL has been disabled. Source: [GitHub blog](https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git).