### PR TITLE
Removed deprecated (now unsupported) rules to fix dependabot failed update (#661)

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -3,9 +3,6 @@
   "rules": {
     "at-rule-empty-line-before": null,
     "at-rule-no-vendor-prefix": null,
-    "block-closing-brace-empty-line-before": null,
-    "block-closing-brace-newline-after": null,
-    "block-opening-brace-space-before": null,
     "color-hex-length": "short",
     "color-named": "never",
     "declaration-empty-line-before": null,
@@ -15,7 +12,6 @@
     "function-url-no-scheme-relative": true,
     "function-url-quotes": "always",
     "length-zero-no-unit": true,
-    "max-line-length": null,
     "media-feature-name-no-vendor-prefix": null,
     "no-descending-specificity": null,
     "no-duplicate-selectors": true,


### PR DESCRIPTION
This should fix #661. Stylelint 16 removed support for deprecated rules from 15 (https://stylelint.io/migration-guide/to-16#breaking-changes). I removed the rules to fix the error. 

For reference, these rules were removed as stylelint has shifted their overall goal to "focus on writing and maintaining rules that help you [avoid errors](https://stylelint.io/user-guide/rules#avoid-errors) and [enforce (non-stylistic) conventions](https://stylelint.io/user-guide/rules#enforce-conventions)" rather than fill the role of both linter and pretty printer. They recommend [Prettier](https://prettier.io/) or [this plugin](https://www.npmjs.com/package/@stylistic/stylelint-plugin) that migrated the deprecated rules.

All four rules were disabled (set to null) so this likely isn't needed anyways, just throwing it out there.